### PR TITLE
Evaluate the channel name as a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ $ somafm listen groovesalad
 22:27:30 | Mindex - Jagga-jah
 ```
 
+You don't have to write the whole channel name, the first letters are enough.
+
+```console
+$ somafm listen groov
+22:27:30 | Mindex - Jagga-jah
+```
+
 ### Listen to Groove Salad at highest quality:
 ```console
 $ somafm listen groovesalad --quality=highest

--- a/src/somafm
+++ b/src/somafm
@@ -65,7 +65,7 @@ function help() {
 
 function listen() {
   local playlist=$(curl -s -H 'Accept: application/json' https://somafm.com/channels.json | \
-    jq -r ".channels | map(select(.id == \"${channel}\")) | .[]" | \
+    jq -r ".channels | map(select(.id | test(\"^${channel}\"))) | .[]" | \
     jq -r ".playlists | map(select(.quality == \"${quality}\")) | limit(1;.[]) | .url")
 
   case "${playlist}" in

--- a/src/somafm
+++ b/src/somafm
@@ -65,7 +65,7 @@ function help() {
 
 function listen() {
   local playlist=$(curl -s -H 'Accept: application/json' https://somafm.com/channels.json | \
-    jq -r ".channels | map(select(.id | test(\"^${channel}\"))) | .[]" | \
+    jq -r ".channels | map(select( (.id == \"${channel}\") or (.id | test(\"^${channel}\")) )) | limit(1;.[])" | \
     jq -r ".playlists | map(select(.quality == \"${quality}\")) | limit(1;.[]) | .url")
 
   case "${playlist}" in


### PR DESCRIPTION
This allows the user to write `somafm listen groove` instead of `somafm listen groovesalad`. It's very convenient. The regex forces the user to write the first letters of the channel, it cannot match
the middle or the end. This is voluntary and should help avoiding unexpected results.